### PR TITLE
Fix type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-export { default as base58_to_binary } from "./base58_to_binary.d.ts";
-export { default as binary_to_base58 } from "./binary_to_base58.d.ts";
+export { default as base58_to_binary } from "./base58_to_binary.js";
+export { default as binary_to_base58 } from "./binary_to_base58.js";


### PR DESCRIPTION
With v3.0.2, I encountered this error with TypeScript:

```text
node_modules/base58-js/index.d.ts:1:45 - error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './base58_to_binary' instead?

1 export { default as base58_to_binary } from "./base58_to_binary.d.ts";
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/base58-js/index.d.ts:2:45 - error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './binary_to_base58' instead?

2 export { default as binary_to_base58 } from "./binary_to_base58.d.ts";
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: node_modules/base58-js/index.d.ts:1
```

To resolve this issue, I changed  `index.d.ts` to import functions from implementation files instead of type declaration files.

Note that using `export type` resulted in another error:

```text
test.mts:3:11 - error TS1362: 'base58_to_binary' cannot be used as a value because it was exported using 'export type'.

3 const a = base58_to_binary("6MRy");
            ~~~~~~~~~~~~~~~~

  ../base58-js/index.d.ts:1:15
    1 export type { default as base58_to_binary } from "./base58_to_binary.d.ts";
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    'base58_to_binary' was exported here.

test.mts:5:13 - error TS1362: 'binary_to_base58' cannot be used as a value because it was exported using 'export type'.

5 console.log(binary_to_base58(a));
              ~~~~~~~~~~~~~~~~

  ../base58-js/index.d.ts:2:15
    2 export type { default as binary_to_base58 } from "./binary_to_base58.d.ts";
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    'binary_to_base58' was exported here.


Found 2 errors in the same file, starting at: test.mts:3
```

test.mts:

```typescript
import { base58_to_binary, binary_to_base58 } from "../base58-js/index.js";

const a = base58_to_binary("6MRy");
console.log(a);
console.log(binary_to_base58(a));
```
