### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const str = binary_to_base58([15, 239, 64]);
 console.log(str);
 ```
 
-> The logged output was Thequickbrownfoxjumpedoverthea1zydog.
+> The logged output was 6MRy.
 
 ## Exports
 


### PR DESCRIPTION
Unless I am mistaken, running the following example from the README outputs `6MRy` and not `Thequickbrownfoxjumpedoverthea1zydog`. Feel free to discard the PR otherwise.

```js
import { binary_to_base58 } from "base58-js";

const str = binary_to_base58([15, 239, 64]);
console.log(str);
```